### PR TITLE
PERF: Optimize StringExtensions.cs

### DIFF
--- a/Messages.Benchmark/Program.cs
+++ b/Messages.Benchmark/Program.cs
@@ -8,6 +8,7 @@ using Perfolizer.Mathematics.OutlierDetection;
 namespace Messages.Benchmark
 {
     #pragma warning disable CA1822 // Mark members as static
+    [MemoryDiagnoser]
     [MinColumn, MaxColumn]
     [MarkdownExporter, HtmlExporter, CsvExporter]
     public class MyBenchmark

--- a/Messages.Helpers/StringExtensions.cs
+++ b/Messages.Helpers/StringExtensions.cs
@@ -14,7 +14,7 @@ public static class StringExtensions
         }
 
         // Filter the message to include only letters and numbers
-        var stringBuilder = new StringBuilder();
+        var stringBuilder = new StringBuilder(message.Length);
         foreach (var letter in message)
         {
             if (char.IsLetterOrDigit(letter))


### PR DESCRIPTION
Hi @dscpinheiro, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
|                      Method |        Mean |     Error |    StdDev |         Min |         Max |  Gen 0 | Allocated |
|---------------------------- |------------:|----------:|----------:|------------:|------------:|-------:|----------:|
|         ShortPalindromeWord |   220.48 ns |  4.332 ns |  4.052 ns |   215.42 ns |   229.99 ns | 0.1373 |     288 B |
|         ShortPalindromeName |   179.03 ns |  3.523 ns |  4.939 ns |   172.81 ns |   192.13 ns | 0.1109 |     232 B |
|             SingleCharacter |    43.47 ns |  0.887 ns |  1.056 ns |    42.22 ns |    46.55 ns | 0.0612 |     128 B |
|   SequenceOfRepeatedNumbers |   639.51 ns | 12.519 ns | 17.550 ns |   613.28 ns |   680.45 ns | 0.3366 |     704 B |
|     SequenceOfRandomNumbers |   178.36 ns |  2.620 ns |  2.451 ns |   174.11 ns |   181.56 ns | 0.0994 |     208 B |
|    EnglishPalindromeMessage | 1,024.09 ns | 20.146 ns | 28.241 ns |   983.52 ns | 1,079.47 ns | 0.4578 |     960 B |
| NonEnglishPalindromeMessage | 1,118.44 ns | 18.662 ns | 21.491 ns | 1,083.15 ns | 1,160.45 ns | 0.5074 |   1,064 B |
|        NonPalindromeMessage |   239.00 ns |  4.524 ns |  4.443 ns |   232.08 ns |   247.54 ns | 0.1526 |     320 B |


**Benchmarks after changes:**
|                      Method |        Mean |     Error |    StdDev |      Median |         Min |         Max |  Gen 0 | Allocated |
|---------------------------- |------------:|----------:|----------:|------------:|------------:|------------:|-------:|----------:|
|         ShortPalindromeWord |   231.60 ns |  6.912 ns | 19.269 ns |   223.97 ns |   213.26 ns |   292.24 ns | 0.1297 |     272 B |
|         ShortPalindromeName |   198.34 ns |  4.791 ns | 13.669 ns |   194.70 ns |   176.70 ns |   234.27 ns | 0.0994 |     208 B |
|             SingleCharacter |    47.43 ns |  0.970 ns |  1.327 ns |    47.30 ns |    45.24 ns |    50.28 ns | 0.0497 |     104 B |
|   SequenceOfRepeatedNumbers |   634.32 ns | 20.411 ns | 55.182 ns |   617.52 ns |   559.45 ns |   813.08 ns | 0.2899 |     608 B |
|     SequenceOfRandomNumbers |   159.61 ns |  3.115 ns |  7.872 ns |   156.98 ns |   147.58 ns |   190.92 ns | 0.0994 |     208 B |
|    EnglishPalindromeMessage | 1,021.58 ns | 19.693 ns | 24.905 ns | 1,014.64 ns |   991.65 ns | 1,094.58 ns | 0.4349 |     912 B |
| NonEnglishPalindromeMessage | 1,051.51 ns | 16.520 ns | 15.453 ns | 1,054.97 ns | 1,030.88 ns | 1,086.89 ns | 0.4807 |   1,008 B |
|        NonPalindromeMessage |   174.84 ns |  3.521 ns |  4.936 ns |   173.32 ns |   167.72 ns |   185.87 ns | 0.1109 |     232 B |

As you can see the allocations have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License*
